### PR TITLE
adds travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: go
+
+go:
+  - "1.x"
+  - "1.8"
+  - "1.10.x"
+  - master

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Slack](https://philips-software-slackin.now.sh/badge.svg)](https://philips-software-slackin.now.sh)
+[![Build Status](https://travis-ci.com/philips-software/go-hsdp-api.svg?branch=master)](https://travis-ci.com/philips-software/go-hsdp-api) [![Slack](https://philips-software-slackin.now.sh/badge.svg)](https://philips-software-slackin.now.sh)
 
 # go-hsdp-api
 


### PR DESCRIPTION
This adds travis-ci to the project.

It tests the libraries against: go 1.x, 1.8, 1.10.x and master.

See https://travis-ci.com/JeroenKnoops/go-hsdp-api/jobs/140985057 for example output.