### PR TITLE
Connect MDM: Add support for Bootstrap OAuth Client Scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -395,3 +395,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 [Unreleased]: https://github.com/philips-software/go-hsdp-api/compare/1.0.0...HEAD
 
+- MDM: Support for bootstrap OAuth client scopes


### PR DESCRIPTION
Added a second function to update client scopes that support choosing between regular client and bootstrap client to avoid code duplication
This is the base for a enhancement for the terraform provider https://github.com/philips-software/terraform-provider-hsdp/issues/179 (I will provide a PR for this as well)

Since this is my first time writing in go (even if it's not that much code...) and first time contributing to this, I'm very open to suggestions and changes

I'm not sure about tests, since there was none for updating scopes initially. If you want that I add one, I can try.